### PR TITLE
Releasing non-initialized gamma a caused memory access violation

### DIFF
--- a/gxruntime/gxgraphics.h
+++ b/gxruntime/gxgraphics.h
@@ -55,7 +55,7 @@ private:
 	std::set<std::string> font_res;
 
 	DDGAMMARAMP _gammaRamp;
-	IDirectDrawGammaControl* _gamma;
+	IDirectDrawGammaControl* _gamma = nullptr;
 
 	/***** GX INTERFACE *****/
 public:


### PR DESCRIPTION
Honestly I don't get why is this function is still here, even though Gamma is for fullscreen only (Specified in the command reference for `SetGamma`).

