### PR TITLE
Add missing Unicode support

### DIFF
--- a/bbruntime/bbgraphics.cpp
+++ b/bbruntime/bbgraphics.cpp
@@ -2030,7 +2030,7 @@ BBStr* bbInput(BBStr* prompt)
             }
             if (key = gx_keyboard->getKey())
             {
-                if (int asc = gx_input->toAscii(key))
+                if (int asc = gx_input->toUnicode(key))
                 {
                     rep_delay = 280;
                     last_key = key;
@@ -2043,7 +2043,7 @@ BBStr* bbInput(BBStr* prompt)
             {
                 if (t - last_time > rep_delay)
                 {
-                    if (key = gx_input->toAscii(last_key))
+                    if (key = gx_input->toUnicode(last_key))
                     {
                         last_time += rep_delay;
                         rep_delay = 40;

--- a/bbruntime/bbinput.cpp
+++ b/bbruntime/bbinput.cpp
@@ -44,7 +44,7 @@ int bbKeyHit(int n) {
 
 int bbGetKey() {
 	if (!gx_input || !gx_keyboard) return 0;
-	return gx_input->toAscii(gx_keyboard->getKey());
+	return gx_input->toUnicode(gx_keyboard->getKey());
 }
 
 BBStr* bbTextInput(BBStr* s) {
@@ -73,7 +73,7 @@ int bbWaitKey() {
 		if (!gx_runtime->idle()) RTEX(0);
 		if (gx_keyboard) {
 			if (int key = gx_keyboard->getKey()) {
-				if (key = gx_input->toAscii(key)) return key;
+				if (key = gx_input->toUnicode(key)) return key;
 			}
 		}
 		gx_runtime->delay(20);

--- a/bbruntime/bbstring.cpp
+++ b/bbruntime/bbstring.cpp
@@ -113,8 +113,11 @@ BBStr* bbRSet(BBStr* s, int n) {
 BBStr* bbChr(int chr) {
 	char buffer[8];
 	int len = UTF8::encodeCharacter(chr, buffer);
-	buffer[len] = '\0';
-	return new BBStr(buffer);
+	
+	BBStr* result = new BBStr();
+	
+	for (int i = 0; i < len; ++i) *result += buffer[i];
+	return result;
 }
 
 BBStr* bbHex(int n) {

--- a/bbruntime/bbstring.cpp
+++ b/bbruntime/bbstring.cpp
@@ -110,9 +110,11 @@ BBStr* bbRSet(BBStr* s, int n) {
 	return s;
 }
 
-BBStr* bbChr(int n) {
-	BBStr* t = new BBStr();
-	*t += (char)n; return t;
+BBStr* bbChr(int chr) {
+	char buffer[8];
+	int len = UTF8::encodeCharacter(chr, buffer);
+	buffer[len] = '\0';
+	return new BBStr(buffer);
 }
 
 BBStr* bbHex(int n) {
@@ -186,7 +188,7 @@ void string_link(void(*rtSym)(const char*, void*)) {
 	rtSym("$Trim$string", bbTrim);
 	rtSym("$LSet$string%size", bbLSet);
 	rtSym("$RSet$string%size", bbRSet);
-	rtSym("$Chr%ascii", bbChr);
+	rtSym("$Chr%unicode", bbChr);
 	rtSym("%Asc$string", bbAsc);
 	rtSym("%Len$string", bbLen);
 	rtSym("$Hex%value", bbHex);

--- a/bbruntime/bbstring.cpp
+++ b/bbruntime/bbstring.cpp
@@ -133,8 +133,12 @@ BBStr* bbBin(int n) {
 }
 
 int bbAsc(BBStr* s) {
-	int n = s->size() ? (*s)[0] & 255 : -1;
-	delete s; return n;
+	if (!s->size()) { delete s; return 0; }
+
+	int n = UTF8::decodeCharacter(s->c_str(), 0);
+
+	delete s;
+	return n;
 }
 
 int bbLen(BBStr* s) {

--- a/gxruntime/gxinput.cpp
+++ b/gxruntime/gxinput.cpp
@@ -460,7 +460,7 @@ bool gxInput::rumble(int port, float left, float right) {
     return SDL_RumbleJoystick(d->joystick, lo, hi, 0xFFFFFFFF);
 }
 
-int gxInput::toAscii(int scan)const {
+int gxInput::toUnicode(int scan)const {
     switch (scan) {
     case DIK_INSERT:return ASC_INSERT;
     case DIK_DELETE:return ASC_DELETE;
@@ -488,7 +488,8 @@ int gxInput::toAscii(int scan)const {
     mat[VK_RMENU] = keyboard->keyDown(DIK_RMENU) ? 0x80 : 0;
     mat[VK_MENU] = mat[VK_LMENU] | mat[VK_RMENU];
 
-    WORD ch;
-    if (ToAscii(virt, scan, mat, &ch, 0) != 1) return 0;
-    return ch & 255;
+    WCHAR ch[4];
+    if (!ToUnicode(virt, scan, mat, ch, 4, 0)) return 0;
+    return (int)ch[0];
 }
+

--- a/gxruntime/gxinput.h
+++ b/gxruntime/gxinput.h
@@ -64,7 +64,7 @@ public:
 	bool getControllerConnected(int port);
 	int getJoystickType(int port)const;
 	int numJoysticks()const;
-	int toAscii(int key)const;
+	int toUnicode(int key)const;
 };
 
 #endif


### PR DESCRIPTION
Adds missing Unicode support to function like `GetKey()` and `Chr()`.
Footage linked below shows the use of this in _SCP:CBM v1.3R_.

https://github.com/user-attachments/assets/e7af34eb-5151-4910-a1ee-dda9f30247a4


