### PR TITLE
Add in ChrRaw() for raw string bytes

### DIFF
--- a/bbruntime/bbstring.cpp
+++ b/bbruntime/bbstring.cpp
@@ -120,6 +120,12 @@ BBStr* bbChr(int chr) {
 	return result;
 }
 
+BBStr* bbChrAscii(int n) {
+	BBStr* t = new BBStr();
+	*t += (char)n;
+	return t;
+}
+
 BBStr* bbHex(int n) {
 	char buff[33];
 	itoa(n, buff, 16);
@@ -196,6 +202,7 @@ void string_link(void(*rtSym)(const char*, void*)) {
 	rtSym("$LSet$string%size", bbLSet);
 	rtSym("$RSet$string%size", bbRSet);
 	rtSym("$Chr%unicode", bbChr);
+	rtSym("$ChrAscii%ascii", bbChrAscii);
 	rtSym("%Asc$string", bbAsc);
 	rtSym("%Len$string", bbLen);
 	rtSym("$Hex%value", bbHex);

--- a/bbruntime/bbstring.cpp
+++ b/bbruntime/bbstring.cpp
@@ -120,7 +120,7 @@ BBStr* bbChr(int chr) {
 	return result;
 }
 
-BBStr* bbChrAscii(int n) {
+BBStr* bbChrRaw(int n) {
 	BBStr* t = new BBStr();
 	*t += (char)n;
 	return t;
@@ -202,7 +202,7 @@ void string_link(void(*rtSym)(const char*, void*)) {
 	rtSym("$LSet$string%size", bbLSet);
 	rtSym("$RSet$string%size", bbRSet);
 	rtSym("$Chr%unicode", bbChr);
-	rtSym("$ChrAscii%ascii", bbChrAscii);
+	rtSym("$ChrRaw%byte", bbChrRaw);
 	rtSym("%Asc$string", bbAsc);
 	rtSym("%Len$string", bbLen);
 	rtSym("$Hex%value", bbHex);

--- a/bbruntime/bbstring.h
+++ b/bbruntime/bbstring.h
@@ -15,7 +15,7 @@ BBStr* bbTrim(BBStr* s);
 BBStr* bbLSet(BBStr* s, int n);
 BBStr* bbRSet(BBStr* s, int n);
 BBStr* bbChr(int n);
-BBStr* bbChrAscii(int n);
+BBStr* bbChrRaw(int n);
 int	   bbAsc(BBStr* s);
 int	   bbLen(BBStr* s);
 BBStr* bbHex(int n);

--- a/bbruntime/bbstring.h
+++ b/bbruntime/bbstring.h
@@ -15,6 +15,7 @@ BBStr* bbTrim(BBStr* s);
 BBStr* bbLSet(BBStr* s, int n);
 BBStr* bbRSet(BBStr* s, int n);
 BBStr* bbChr(int n);
+BBStr* bbChrAscii(int n);
 int	   bbAsc(BBStr* s);
 int	   bbLen(BBStr* s);
 BBStr* bbHex(int n);


### PR DESCRIPTION
Adds `ChrRaw()` which is required in `ReadINILine()`.

`ReadINILine()` reads the file byte-by-byte so it needs to append the raw byte values without treating them as Unicode codepoints.
`ChrRaw()` preserves the original byte values, allowing UTF-8 sequences to remain intact.

_I forgot to add this in #40._
