### PR TITLE
Handle WM_CHAR in windowProc

### DIFF
--- a/gxruntime/gxruntime.cpp
+++ b/gxruntime/gxruntime.cpp
@@ -619,6 +619,9 @@ LRESULT gxRuntime::windowProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 		case WM_KEYUP:case WM_SYSKEYUP:
 			if(int n = ((lparam >> 17) & 0x80) | ((lparam >> 16) & 0x7f)) input->wm_keyup(n);
 			break;
+		case WM_CHAR:
+			input->wm_char(wparam, lparam);
+			break;
 		default:
 			return DefWindowProc(hwnd, msg, wparam, lparam);
 	}
@@ -675,9 +678,6 @@ bool gxRuntime::idle() {
 			case WM_END:
 				debugger = 0;
 				run_flag = false;
-				break;
-			case WM_CHAR:
-				input->wm_char(msg.wParam, msg.lParam);
 				break;
 			default:
 				TranslateMessage(&msg);


### PR DESCRIPTION
Actually fixes #16 for good.

A `PeekMessage` loop introduced in https://github.com/krimbopple/BlitzX3D/commit/251199fa12a35f1deb349962f27944e1a0323fae caused some `WM_CHAR` messages to be removed from the message queue before `gxRuntime::idle` could handle them. This moves the `WM_CHAR` handler into `gxRuntime::windowProc` where it belongs, completely avoiding any message queue issues.