### PR TITLE
Fix output width being a fixed value instead of being the available width size

### DIFF
--- a/blitzide_imgui/app.cpp
+++ b/blitzide_imgui/app.cpp
@@ -870,7 +870,7 @@ void App::drawOutput() {
 
 	ImGui::PushStyleColor(ImGuiCol_Text, compileOK ? IM_COL32(200, 255, 200, 255) : IM_COL32(255, 200, 200, 255));
 	ImGui::InputTextMultiline("##output", (char*)outputView.c_str(), (int)outputView.capacity() + 1,
-		ImVec2(0, -ImGui::GetFrameHeightWithSpacing() - 4),
+		ImVec2(ImGui::GetContentRegionAvail().x, -ImGui::GetFrameHeightWithSpacing() - 4),
 		ImGuiInputTextFlags_ReadOnly | ImGuiInputTextFlags_NoUndoRedo | ImGuiInputTextFlags_CallbackResize,
 		OutputTextResizeCallback, (void*)&outputView);
 	ImGui::PopStyleColor();


### PR DESCRIPTION
This was bugging me A LOT!!!

Before:
<img width="1161" height="203" alt="image" src="https://github.com/user-attachments/assets/26c22589-15fc-473b-900e-cef2fbb9410e" />

After:
<img width="1149" height="196" alt="image" src="https://github.com/user-attachments/assets/7471ef70-6cbd-455a-a0a7-1f3b24a6e16e" />
